### PR TITLE
fixed URI::InvalidURIError caused by unescaped params.

### DIFF
--- a/lib/paczkomaty_inpost/request.rb
+++ b/lib/paczkomaty_inpost/request.rb
@@ -332,6 +332,7 @@ module PaczkomatyInpost
     private
 
     def get_response(params)
+      params = URI.escape(params)
       uri = URI.parse("#{PaczkomatyInpost.inpost_api_url}#{params}")
       begin
         response = Net::HTTP.get_response(uri)


### PR DESCRIPTION
Added escape params in get_response method.
